### PR TITLE
Add CODEOWNERS file to auto-assign PR reviewers

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,2 @@
+# This assigns both Visu and Scorpio as reviewers for all files
+* @visu-suganya @scorpio-naveen


### PR DESCRIPTION
- Introduced a `.github/CODEOWNERS` file that automatically assigns code reviewers for pull requests.
- To streamline the review process and ensure consistency especially for changes across the repository.
- Automatically assigns @visu-suganya  and @scorpio-naveen as reviewers for all changes.

